### PR TITLE
Fixes native PHP template syntax

### DIFF
--- a/resources/syntax/octoberTemplate.tmLanguage.json
+++ b/resources/syntax/octoberTemplate.tmLanguage.json
@@ -5,8 +5,21 @@
     "patterns": [
         {
             "contentName": "source.php.octoberTemplate",
-            "begin": "\\<\\?php",
-            "end": "\\?\\>",
+            "begin": "<\\?(?i:php|=)?(?![^?]*\\?>)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.php"
+                }
+            },
+            "end": "(\\?)>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.php"
+                },
+                "1": {
+                    "name": "source.php"
+                }
+            },
             "patterns": [
                 {
                     "patterns": [


### PR DESCRIPTION
October CMS will internally process short tags `<? ?>` even if PHP doesn't support them, so we can use it to enable the shorter syntax. This also highlights the opening and closing tags.

### Before Change (A)

![image](https://user-images.githubusercontent.com/1392869/193213541-7fe7a349-15d8-4d6a-948a-e5f7dc5a9ef4.png)

### Before Change (B)

![image](https://user-images.githubusercontent.com/1392869/193213668-6f393269-bf99-4cf9-9bde-37170a308942.png)

### After Change (A)

![image](https://user-images.githubusercontent.com/1392869/193213988-fcb1cc75-ca1b-4d82-955e-f81e43dae074.png)

### After Change (B)

![image](https://user-images.githubusercontent.com/1392869/193213834-e8b3f20b-8984-4b3f-8ec7-d179db91ab90.png)
